### PR TITLE
Added support for the CMD_DEBUG_EXT_STOPGO packet.

### DIFF
--- a/libframe4/FRAME4.Debug.cs
+++ b/libframe4/FRAME4.Debug.cs
@@ -22,6 +22,7 @@ namespace libframe4
         private const int CMD_DEBUG_SETREGS_PACKET_SIZE = 8;
         private const int CMD_DEBUG_STOPGO_PACKET_SIZE = 4;
         private const int CMD_DEBUG_THRINFO_PACKET_SIZE = 4;
+        private const int CMD_DEBUG_EXT_STOPGO_PACKET_SIZE = 5;
 
         // receive size
         private const int DEBUG_INTERRUPT_SIZE = 0x4A0;
@@ -200,6 +201,45 @@ namespace libframe4
             CheckDebugging();
 
             SendCMDPacket(CMDS.CMD_DEBUG_STOPGO, CMD_DEBUG_STOPGO_PACKET_SIZE, 0);
+            CheckStatus();
+        }
+
+        /// <summary>
+        /// Stop the current process without detach the debugger.
+        /// This feature has been supported since PACKET_VERSION 0.2.15
+        /// </summary>
+        /// <param name="pid"></param>
+        public void ProcessExtStop(int pid)
+        {
+            CheckConnected();
+
+            SendCMDPacket(CMDS.CMD_DEBUG_EXT_STOPGO, CMD_DEBUG_EXT_STOPGO_PACKET_SIZE, (uint)pid, (byte)1);
+            CheckStatus();
+        }
+
+        /// <summary>
+        /// Resume the current process without detach the debugger.
+        /// This feature has been supported since PACKET_VERSION 0.2.15
+        /// </summary>
+        /// <param name="pid"></param>
+        public void ProcessExtKill(int pid)
+        {
+            CheckConnected();
+
+            SendCMDPacket(CMDS.CMD_DEBUG_EXT_STOPGO, CMD_DEBUG_EXT_STOPGO_PACKET_SIZE, (uint)pid, (byte)2);
+            CheckStatus();
+        }
+
+        /// <summary>
+        /// Kill the current process without detach the debugger.
+        /// This feature has been supported since PACKET_VERSION 0.2.15
+        /// </summary>
+        /// <param name="pid"></param>
+        public void ProcessExtResume(int pid)
+        {
+            CheckConnected();
+
+            SendCMDPacket(CMDS.CMD_DEBUG_EXT_STOPGO, CMD_DEBUG_EXT_STOPGO_PACKET_SIZE, (uint)pid, (byte)0);
             CheckStatus();
         }
 

--- a/libframe4/FRAME4.cs
+++ b/libframe4/FRAME4.cs
@@ -93,6 +93,7 @@ namespace libframe4
             CMD_DEBUG_STOPGO = 0xBDBB0010,
             CMD_DEBUG_THRINFO = 0xBDBB0011,
             CMD_DEBUG_SINGLESTEP = 0xBDBB0012,
+            CMD_DEBUG_EXT_STOPGO = 0xBDBB0500,
 
             CMD_KERN_BASE = 0xBDCC0001,
             CMD_KERN_READ = 0xBDCC0002,


### PR DESCRIPTION
Added three methods: ProcessExtStop, ProcessExtKill, and ProcessExtResume, which use CMD_DEBUG_EXT_STOPGO. The extended versions of stop, kill, and resume can be executed without detaching the debugger.